### PR TITLE
Addition of unit tests and code refactoring to closer align SOLID principles

### DIFF
--- a/MailContainerTest.Tests/MailContainerStoreProviderTests.cs
+++ b/MailContainerTest.Tests/MailContainerStoreProviderTests.cs
@@ -1,6 +1,8 @@
 ﻿using MailContainerTest.Data;
 using MailContainerTest.Providers;
+using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
@@ -14,11 +16,12 @@ namespace MailContainerTest.Tests
     public class MailContainerStoreProviderTests
     {
         private MailContainerStoreProvider _provider;
+        private Mock<IConfiguration> _mockConfiguration;
 
         [TestInitialize]
         public void Initialise()
         {
-            _provider = new MailContainerStoreProvider();
+            _mockConfiguration = new Mock<IConfiguration>();
         }
 
         [DataTestMethod]
@@ -27,10 +30,11 @@ namespace MailContainerTest.Tests
         public void MakeMailTransfer_ShouldLookupCorrectDataStore(string dataStoreType, Type desiredStore)
         {
             // Arrange
-            ConfigurationManager.AppSettings["DataStoreType"] = dataStoreType;
+            _mockConfiguration.SetupGet(p => p["DataStoreType"]).Returns(dataStoreType);
+            _provider = new MailContainerStoreProvider(_mockConfiguration.Object);
 
             // Act
-            var dataStore = _provider.GetDataStoreForType(dataStoreType);
+            var dataStore = _provider.GetDataStore();
 
             // Assert
             Assert.IsInstanceOfType(dataStore, desiredStore);

--- a/MailContainerTest.Tests/MailContainerStoreProviderTests.cs
+++ b/MailContainerTest.Tests/MailContainerStoreProviderTests.cs
@@ -1,0 +1,39 @@
+﻿using MailContainerTest.Data;
+using MailContainerTest.Providers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Tests
+{
+    [TestClass]
+    public class MailContainerStoreProviderTests
+    {
+        private MailContainerStoreProvider _provider;
+
+        [TestInitialize]
+        public void Initialise()
+        {
+            _provider = new MailContainerStoreProvider();
+        }
+
+        [DataTestMethod]
+        [DataRow("Backup", typeof(BackupMailContainerDataStore))]
+        [DataRow("Other", typeof(MailContainerDataStore))]
+        public void MakeMailTransfer_ShouldLookupCorrectDataStore(string dataStoreType, Type desiredStore)
+        {
+            // Arrange
+            ConfigurationManager.AppSettings["DataStoreType"] = dataStoreType;
+
+            // Act
+            var dataStore = _provider.GetDataStoreForType(dataStoreType);
+
+            // Assert
+            Assert.IsInstanceOfType(dataStore, desiredStore);
+        }
+    }
+}

--- a/MailContainerTest.Tests/MailContainerTest.Tests.csproj
+++ b/MailContainerTest.Tests/MailContainerTest.Tests.csproj
@@ -1,9 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MailContainerTest\MailContainerTest.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/MailContainerTest.Tests/MailTransferServiceTests.cs
+++ b/MailContainerTest.Tests/MailTransferServiceTests.cs
@@ -1,0 +1,161 @@
+﻿using MailContainerTest.Services;
+using MailContainerTest.Types;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Tests
+{
+    [TestClass]
+    public class MailTransferServiceTests
+    {
+        private MailTransferService _service;
+
+        [TestInitialize]
+        public void Initialise()
+        {
+            this._service = new MailTransferService();
+        }
+
+        [DataTestMethod]
+        [DataRow("Backup")]
+        [DataRow("Other")]
+        public void MakeMailTransfer_ShouldLookupCorrectDataStore(string dataStoreType)
+        {
+            // Arrange
+            ConfigurationManager.AppSettings["DataStoreType"] = dataStoreType;
+
+            var request = new MakeMailTransferRequest
+            {
+                SourceMailContainerNumber = "1",
+                DestinationMailContainerNumber = "2",
+                NumberOfMailItems = 1,
+                TransferDate = DateTime.UtcNow,
+                MailType = MailType.SmallParcel
+            };
+
+            // Act
+            _service.MakeMailTransfer(request);
+
+            // Assert
+            // unable to assert correct data store at present - refactoring required
+        }
+
+        [DataTestMethod]
+        [DataRow(MailType.LargeLetter, AllowedMailType.LargeLetter)]
+        [DataRow(MailType.StandardLetter, AllowedMailType.StandardLetter)]
+        [DataRow(MailType.SmallParcel, AllowedMailType.SmallParcel)]
+        public void MakeMailTransfer_ShouldAllowTransferToAllowedMailTypes(MailType requestMailType, AllowedMailType allowedMailType)
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest
+            {
+                SourceMailContainerNumber = "1",
+                DestinationMailContainerNumber = "2",
+                NumberOfMailItems = 1,
+                TransferDate = DateTime.UtcNow,
+                MailType = requestMailType
+            };
+
+            // need to mock mail container 
+            // container needs to be operational
+            // container needs to have capacity
+            // container must accept correct mail type
+
+            // Act
+            var result = _service.MakeMailTransfer(request);
+
+            // Assert
+            Assert.IsFalse(result.Success);
+        }
+
+        [DataTestMethod]
+        [DataRow(MailType.LargeLetter)]
+        [DataRow(MailType.StandardLetter)]
+        [DataRow(MailType.SmallParcel)]
+        public void MakeMailTransfer_ShouldNotAllowTransferToNonOperationalMailContainers(MailType requestMailType)
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest
+            {
+                SourceMailContainerNumber = "1",
+                DestinationMailContainerNumber = "2",
+                NumberOfMailItems = 1,
+                TransferDate = DateTime.UtcNow,
+                MailType = requestMailType
+            };
+
+            // need to mock mail container 
+            // container needs to be non operational
+            // container needs to have capacity
+            // container must accept correct mail type
+
+            // Act
+            var result = _service.MakeMailTransfer(request);
+
+            // Assert
+            Assert.IsFalse(result.Success);
+        }
+
+        [DataTestMethod]
+        [DataRow(MailType.LargeLetter)]
+        [DataRow(MailType.StandardLetter)]
+        [DataRow(MailType.SmallParcel)]
+        public void MakeMailTransfer_ShouldNotAllowTransferToMailContainersWithoutCapacity(MailType requestMailType)
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest
+            {
+                SourceMailContainerNumber = "1",
+                DestinationMailContainerNumber = "2",
+                NumberOfMailItems = 1,
+                TransferDate = DateTime.UtcNow,
+                MailType = requestMailType
+            };
+
+            // need to mock mail container 
+            // container needs to be operational
+            // container needs to NOT have capacity
+            // container must accept correct mail type
+
+            // Act
+            var result = _service.MakeMailTransfer(request);
+
+            // Assert
+            Assert.IsFalse(result.Success);
+        }
+
+        [DataTestMethod]
+        [DataRow(MailType.LargeLetter)]
+        [DataRow(MailType.StandardLetter)]
+        [DataRow(MailType.SmallParcel)]
+        public void MakeMailTransfer_ShouldUpdateMailContainer(MailType requestMailType)
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest
+            {
+                SourceMailContainerNumber = "1",
+                DestinationMailContainerNumber = "2",
+                NumberOfMailItems = 1,
+                TransferDate = DateTime.UtcNow,
+                MailType = requestMailType
+            };
+
+            // need to mock mail container 
+            // container needs to be operational
+            // container needs to NOT have capacity
+            // container must accept correct mail type
+
+            // Act
+            var result = _service.MakeMailTransfer(request);
+
+            // Assert
+            
+            // cannot verify at present
+        }
+    }
+}

--- a/MailContainerTest.Tests/MailTransferServiceTests.cs
+++ b/MailContainerTest.Tests/MailTransferServiceTests.cs
@@ -23,34 +23,16 @@ namespace MailContainerTest.Tests
 
         private Mock<IMailContainerDataStore> _mockMailContainerStore;
 
-        private Mock<IConfiguration> _mockConfiguration;
-
         [TestInitialize]
         public void Initialise()
         {
             _mockMailContainerStoreProvider = new Mock<IMailContainerStoreProvider>();
             _mockMailContainerStore = new Mock<IMailContainerDataStore>();
-            _mockConfiguration = new Mock<IConfiguration>();
 
-            _mockMailContainerStoreProvider.Setup(x => x.GetDataStoreForType(It.IsAny<string>()))
+            _mockMailContainerStoreProvider.Setup(x => x.GetDataStore())
                 .Returns(_mockMailContainerStore.Object);
 
-            _service = new MailTransferService(_mockMailContainerStoreProvider.Object, _mockConfiguration.Object);
-        }
-
-        [DataTestMethod]
-        [DataRow("Backup")]
-        [DataRow("Normal")]
-        public void MailTransferService_Ctr_ShouldGetCorrectDataStore(string dataStoreType)
-        {
-            // Arrange
-            _mockConfiguration.SetupGet(p => p["DataStoreType"]).Returns(dataStoreType);
-
-            // Act
-            _service = new MailTransferService(_mockMailContainerStoreProvider.Object, _mockConfiguration.Object);
-
-            // Assert
-            _mockMailContainerStoreProvider.Verify(x => x.GetDataStoreForType(dataStoreType), Times.Once());
+            _service = new MailTransferService(_mockMailContainerStoreProvider.Object);
         }
 
         [TestMethod]

--- a/MailContainerTest.Tests/MailTransferServiceTests.cs
+++ b/MailContainerTest.Tests/MailTransferServiceTests.cs
@@ -70,7 +70,7 @@ namespace MailContainerTest.Tests
             var result = _service.MakeMailTransfer(request);
 
             // Assert
-            Assert.IsFalse(result.Success);
+            Assert.IsTrue(result.Success);
         }
 
         [DataTestMethod]

--- a/MailContainerTest/Data/BackupMailContainerDataStore.cs
+++ b/MailContainerTest/Data/BackupMailContainerDataStore.cs
@@ -2,7 +2,7 @@
 
 namespace MailContainerTest.Data
 {
-    public class BackupMailContainerDataStore
+    public class BackupMailContainerDataStore : IMailContainerDataStore
     {
         public MailContainer GetMailContainer(string mailContainerNumber)
         {

--- a/MailContainerTest/Data/IMailContainerDataStore.cs
+++ b/MailContainerTest/Data/IMailContainerDataStore.cs
@@ -1,0 +1,10 @@
+﻿using MailContainerTest.Types;
+
+namespace MailContainerTest.Data
+{
+    public interface IMailContainerDataStore
+    {
+        MailContainer GetMailContainer(string mailContainerNumber);
+        void UpdateMailContainer(MailContainer mailContainer);
+    }
+}

--- a/MailContainerTest/Data/MailContainerDataStore.cs
+++ b/MailContainerTest/Data/MailContainerDataStore.cs
@@ -2,10 +2,10 @@
 
 namespace MailContainerTest.Data
 {
-    public class MailContainerDataStore
+    public class MailContainerDataStore : IMailContainerDataStore
     {
         public MailContainer GetMailContainer(string mailContainerNumber)
-        {   
+        {
             // Access the database and return the retrieved mail container. Implementation not required for this exercise.
             return new MailContainer();
         }

--- a/MailContainerTest/MailContainerTest.csproj
+++ b/MailContainerTest/MailContainerTest.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
   </ItemGroup>
 

--- a/MailContainerTest/Providers/IMailContainerStoreProvider.cs
+++ b/MailContainerTest/Providers/IMailContainerStoreProvider.cs
@@ -4,6 +4,6 @@ namespace MailContainerTest.Providers
 {
     public interface IMailContainerStoreProvider
     {
-        IMailContainerDataStore GetDataStoreForType(string type);
+        IMailContainerDataStore GetDataStore();
     }
 }

--- a/MailContainerTest/Providers/IMailContainerStoreProvider.cs
+++ b/MailContainerTest/Providers/IMailContainerStoreProvider.cs
@@ -1,0 +1,9 @@
+﻿using MailContainerTest.Data;
+
+namespace MailContainerTest.Providers
+{
+    public interface IMailContainerStoreProvider
+    {
+        IMailContainerDataStore GetDataStoreForType(string type);
+    }
+}

--- a/MailContainerTest/Providers/MailContainerStoreProvider.cs
+++ b/MailContainerTest/Providers/MailContainerStoreProvider.cs
@@ -11,7 +11,7 @@ namespace MailContainerTest.Providers
     {
         public IMailContainerDataStore GetDataStoreForType(string type)
         {
-            if (type == "DataStoreType")
+            if (type == "Backup")
             {
                 return new BackupMailContainerDataStore();
             }

--- a/MailContainerTest/Providers/MailContainerStoreProvider.cs
+++ b/MailContainerTest/Providers/MailContainerStoreProvider.cs
@@ -1,4 +1,5 @@
 ﻿using MailContainerTest.Data;
+using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,9 +10,16 @@ namespace MailContainerTest.Providers
 {
     public class MailContainerStoreProvider : IMailContainerStoreProvider
     {
-        public IMailContainerDataStore GetDataStoreForType(string type)
+        private string _dataStoreType;
+
+        public MailContainerStoreProvider(IConfiguration configuration)
         {
-            if (type == "Backup")
+            _dataStoreType = configuration["DataStoreType"];
+        }
+
+        public IMailContainerDataStore GetDataStore()
+        {
+            if (_dataStoreType == "Backup")
             {
                 return new BackupMailContainerDataStore();
             }

--- a/MailContainerTest/Providers/MailContainerStoreProvider.cs
+++ b/MailContainerTest/Providers/MailContainerStoreProvider.cs
@@ -1,0 +1,24 @@
+﻿using MailContainerTest.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Providers
+{
+    public class MailContainerStoreProvider : IMailContainerStoreProvider
+    {
+        public IMailContainerDataStore GetDataStoreForType(string type)
+        {
+            if (type == "DataStoreType")
+            {
+                return new BackupMailContainerDataStore();
+            }
+            else
+            {
+                return new MailContainerDataStore();
+            }
+        }
+    }
+}

--- a/MailContainerTest/Services/MailTransferService.cs
+++ b/MailContainerTest/Services/MailTransferService.cs
@@ -11,13 +11,11 @@ namespace MailContainerTest.Services
         private IMailContainerStoreProvider _mailContainerStoreProvider;
         private IMailContainerDataStore _mailContainerDataStore;
 
-        public MailTransferService(IMailContainerStoreProvider mailContainerStoreProvider, IConfiguration configuration)
+        public MailTransferService(IMailContainerStoreProvider mailContainerStoreProvider)
         {
-            var dataStoreType = configuration["DataStoreType"];
-
             _mailContainerStoreProvider = mailContainerStoreProvider;
 
-            _mailContainerDataStore = _mailContainerStoreProvider.GetDataStoreForType(dataStoreType);
+            _mailContainerDataStore = _mailContainerStoreProvider.GetDataStore();
         }
 
         public MakeMailTransferResult MakeMailTransfer(MakeMailTransferRequest request)

--- a/MailContainerTest/Services/MailTransferService.cs
+++ b/MailContainerTest/Services/MailTransferService.cs
@@ -1,5 +1,6 @@
 ﻿using MailContainerTest.Data;
 using MailContainerTest.Types;
+using Microsoft.Extensions.Configuration;
 using System.Configuration;
 
 namespace MailContainerTest.Services

--- a/MailContainerTest/Types/AllowedMailType.cs
+++ b/MailContainerTest/Types/AllowedMailType.cs
@@ -1,9 +1,0 @@
-﻿namespace MailContainerTest.Types
-{
-    public enum AllowedMailType
-    {
-        StandardLetter = 1 ,
-        LargeLetter = 2,   
-        SmallParcel = 3
-    }
-}

--- a/MailContainerTest/Types/MailContainer.cs
+++ b/MailContainerTest/Types/MailContainer.cs
@@ -5,7 +5,7 @@
         public string MailContainerNumber { get; set; } 
         public int Capacity { get; set; }   
         public MailContainerStatus Status { get; set; }
-        public AllowedMailType AllowedMailType { get; set; }
+        public MailType AllowedMailType { get; set; }
 
     }
 }


### PR DESCRIPTION
- Addition of unit tests to cover business logic for the MailTransferService, covering success scenarios and expected error scenarios

- Addition of a MailContainerStoreProvider to ensure the correct concretion of IMailContainerStoreProvider is returned based on IConfiguration

Summary of changes to MailTransferService:
- Addition of constructor to allow injection of IConfiguration and a IMailContainerStoreProvider
- Moving of app configuration check to constructor and ensure the correct mail container store is retrieved from the provider. I would assume this service would be bound in transient scope so this logically lives in the constructor
- Replace redundant switch statement for different MailTypes as business logic should be the same for all mail types
- Remove AllowedMailType enum as this is duplicate of the MailType enum and is prone to cause confusion

I have spent about about 2.5 hours on and off throughout the day on this PR, I would have wanted to do more with it but wanted to stick as close as possible to the time constraint. I have added PR comments where I would like to take this further.