### PR TITLE
Refactor MailTransferService and add unit tests

### DIFF
--- a/MailContainerTest.Tests/MailContainerTest.Tests.csproj
+++ b/MailContainerTest.Tests/MailContainerTest.Tests.csproj
@@ -6,4 +6,16 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MailContainerTest\MailContainerTest.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/MailContainerTest.Tests/Services/MailTransferServiceTests.cs
+++ b/MailContainerTest.Tests/Services/MailTransferServiceTests.cs
@@ -1,0 +1,184 @@
+﻿using Moq;
+using NUnit.Framework;
+using FluentAssertions;
+using MailContainerTest.Data;
+using MailContainerTest.Services;
+using MailContainerTest.Services.Interfaces;
+using MailContainerTest.Types;
+
+namespace MailContainerTest.Tests.Services
+{
+    [TestFixture]
+    public class MailTransferServiceTests
+    {
+        private Mock<IMailContainerDataStore> mailContainerDataStoreMock;
+        private Mock<IMailValidator> mailTransferValidatorMock;
+        private MailTransferService sut;
+
+        [SetUp]
+        public void Setup()
+        {
+            mailContainerDataStoreMock = new Mock<IMailContainerDataStore>();
+            mailTransferValidatorMock = new Mock<IMailValidator>();
+            sut = new MailTransferService(mailContainerDataStoreMock.Object, mailTransferValidatorMock.Object);
+        }
+
+        [Test]
+        public void ValidLetterRequestReturnsTrue()
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.StandardLetter
+            };
+
+            var mailContainer = new MailContainer()
+            {
+                AllowedMailType = AllowedMailType.StandardLetter
+            };
+
+            mailContainerDataStoreMock.Setup(m => m.GetMailContainer(It.IsAny<string>())).Returns(mailContainer);
+            mailTransferValidatorMock.Setup(m => m.IsMailValid(It.IsAny<MailContainer>(), It.IsAny<MakeMailTransferRequest>())).Returns(true);
+
+            // Act
+            var result = sut.MakeMailTransfer(request);
+
+            // Assert
+            result.Success.Should().BeTrue();
+        }
+
+        [Test]
+        public void InvalidLetterRequestReturnsFalse()
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.StandardLetter
+            };
+
+            var mailContainer = new MailContainer()
+            {
+                AllowedMailType = AllowedMailType.LargeLetter
+            };
+
+            mailContainerDataStoreMock.Setup(m => m.GetMailContainer(It.IsAny<string>())).Returns(mailContainer);
+            mailTransferValidatorMock.Setup(m => m.IsMailValid(It.IsAny<MailContainer>(), It.IsAny<MakeMailTransferRequest>())).Returns(false);
+
+            // Act
+            var result = sut.MakeMailTransfer(request);
+
+            // Assert
+            result.Success.Should().BeFalse();
+        }
+
+        [Test]
+        public void GetMailContainerIsCalled()
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest()
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.LargeLetter,
+                NumberOfMailItems = 3
+            };
+
+            var mailContainer = new MailContainer()
+            {
+                AllowedMailType = AllowedMailType.LargeLetter,
+                Capacity = 3
+            };
+
+            mailContainerDataStoreMock.Setup(m => m.GetMailContainer(It.IsAny<string>())).Returns(mailContainer);
+            mailTransferValidatorMock.Setup(m => m.IsMailValid(It.IsAny<MailContainer>(), It.IsAny<MakeMailTransferRequest>())).Returns(true);
+
+            // Act
+            var result = sut.MakeMailTransfer(request);
+
+            // Assert
+            mailContainerDataStoreMock.Verify(m => m.GetMailContainer(It.IsAny<string>()), Times.Once());
+        }
+
+        [Test]
+        public void IsMailValidIsCalled()
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest()
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.LargeLetter,
+                NumberOfMailItems = 3
+            };
+
+            var mailContainer = new MailContainer()
+            {
+                AllowedMailType = AllowedMailType.LargeLetter,
+                Capacity = 3
+            };
+
+            mailContainerDataStoreMock.Setup(m => m.GetMailContainer(It.IsAny<string>())).Returns(mailContainer);
+            mailTransferValidatorMock.Setup(m => m.IsMailValid(It.IsAny<MailContainer>(), It.IsAny<MakeMailTransferRequest>())).Returns(true);
+
+            // Act
+            var result = sut.MakeMailTransfer(request);
+
+            // Assert
+            mailTransferValidatorMock.Verify(m => m.IsMailValid(It.IsAny<MailContainer>(), It.IsAny<MakeMailTransferRequest>()), Times.Once());
+        }
+
+        [Test]
+        public void CapacityReduceWhenMailIsValid()
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest()
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.LargeLetter,
+                NumberOfMailItems = 2
+            };
+
+            var mailContainer = new MailContainer()
+            {
+                AllowedMailType = AllowedMailType.LargeLetter,
+                Capacity = 3
+            };
+
+            mailContainerDataStoreMock.Setup(m => m.GetMailContainer(It.IsAny<string>())).Returns(mailContainer);
+            mailTransferValidatorMock.Setup(m => m.IsMailValid(It.IsAny<MailContainer>(), It.IsAny<MakeMailTransferRequest>())).Returns(true);
+
+            // Act
+            var result = sut.MakeMailTransfer(request);
+
+            // Assert
+            mailContainer.Capacity.Should().Be(1);
+        }
+
+        [Test]
+        public void CapacityNotReducedWhenMailValidationFails()
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest()
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.LargeLetter,
+                NumberOfMailItems = 2
+            };
+
+            var mailContainer = new MailContainer()
+            {
+                AllowedMailType = AllowedMailType.SmallParcel,
+                Capacity = 3
+            };
+
+            mailContainerDataStoreMock.Setup(m => m.GetMailContainer(It.IsAny<string>())).Returns(mailContainer);
+            mailTransferValidatorMock.Setup(m => m.IsMailValid(It.IsAny<MailContainer>(), It.IsAny<MakeMailTransferRequest>())).Returns(false);
+
+            // Act
+            var result = sut.MakeMailTransfer(request);
+
+            // Assert
+            mailContainer.Capacity.Should().Be(3);
+        }
+    }
+}

--- a/MailContainerTest.Tests/Services/MailValidatorTests.cs
+++ b/MailContainerTest.Tests/Services/MailValidatorTests.cs
@@ -1,0 +1,184 @@
+﻿using FluentAssertions;
+using MailContainerTest.Services;
+using MailContainerTest.Services.Interfaces;
+using MailContainerTest.Types;
+using NUnit.Framework;
+
+namespace MailContainerTest.Tests.Services
+{
+    [TestFixture]
+    public class MailValidatorTests
+    {
+        private IMailValidator sut;
+
+
+        [SetUp]
+        public void Setup()
+        {
+            sut = new MailValidator();
+        }
+
+        [Test]
+        public void ValidStandardLetterReturnsTrue()
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.StandardLetter
+            };
+
+            var mailContainer = new MailContainer()
+            {
+                AllowedMailType = AllowedMailType.StandardLetter
+            };
+
+            // Act
+            var result = sut.IsMailValid(mailContainer, request);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void ValidLargeLetterReturnsTrue()
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest()
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.LargeLetter,
+                NumberOfMailItems = 3
+            };
+
+            var mailContainer = new MailContainer()
+            {
+                AllowedMailType = AllowedMailType.LargeLetter,
+                Capacity = 3
+            };
+
+            
+            // Act
+            var result = sut.IsMailValid(mailContainer, request);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void ValidSmallParcellReturnsTrue()
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest()
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.SmallParcel,
+            };
+
+            var mailContainer = new MailContainer()
+            {
+                AllowedMailType = AllowedMailType.SmallParcel,
+                Status = MailContainerStatus.Operational
+            };
+
+            // Act
+            var result = sut.IsMailValid(mailContainer, request);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Test]
+        public void MailContainerNotInstantiatedReturnsFalse()
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest()
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.StandardLetter
+            };
+
+            MailContainer mailContainer = null;
+
+            // Act
+            var result = sut.IsMailValid(mailContainer, request);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Test]
+        public void InvalidStandardLetterReturnsFalse()
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest()
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.StandardLetter
+            };
+
+            var mailContainer = new MailContainer()
+            {
+                AllowedMailType = AllowedMailType.LargeLetter
+            };
+
+            // Act
+            var result = sut.IsMailValid(mailContainer, request);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [TestCase(MailType.StandardLetter, 2)]
+        [TestCase(MailType.LargeLetter, 1)]
+        [TestCase(MailType.StandardLetter, 1)]
+        public void InvalidLargeLetterReturnsFalse(AllowedMailType mailType, int capacity)
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest()
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.LargeLetter,
+                NumberOfMailItems = 2
+            };
+
+            var mailContainer = new MailContainer()
+            {
+                AllowedMailType = mailType,
+                Capacity = capacity
+            };
+
+            // Act
+            var result = sut.IsMailValid(mailContainer, request);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [TestCase(MailType.StandardLetter, MailContainerStatus.Operational)]
+        [TestCase(MailType.SmallParcel, MailContainerStatus.OutOfService)]
+        [TestCase(MailType.StandardLetter, MailContainerStatus.OutOfService)]
+        public void InvalidSmallParcelReturnsFalse(AllowedMailType mailType, MailContainerStatus containerStatus)
+        {
+            // Arrange
+            var request = new MakeMailTransferRequest()
+            {
+                SourceMailContainerNumber = "123",
+                MailType = MailType.SmallParcel,
+                NumberOfMailItems = 2
+            };
+
+            var mailContainer = new MailContainer()
+            {
+                AllowedMailType = mailType,
+                Status = containerStatus
+            };
+
+            // Act
+            var result = sut.IsMailValid(mailContainer, request);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+}

--- a/MailContainerTest/Data/BackupMailContainerDataStore.cs
+++ b/MailContainerTest/Data/BackupMailContainerDataStore.cs
@@ -2,7 +2,7 @@
 
 namespace MailContainerTest.Data
 {
-    public class BackupMailContainerDataStore
+    public class BackupMailContainerDataStore : IMailContainerDataStore
     {
         public MailContainer GetMailContainer(string mailContainerNumber)
         {

--- a/MailContainerTest/Data/IMailContainerDataStore.cs
+++ b/MailContainerTest/Data/IMailContainerDataStore.cs
@@ -1,0 +1,15 @@
+﻿using MailContainerTest.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Data
+{
+    public interface IMailContainerDataStore
+    {
+        public MailContainer GetMailContainer(string mailContainerNumber);
+        public void UpdateMailContainer(MailContainer mailContainer);
+    }
+}

--- a/MailContainerTest/Data/MailContainerDataStore.cs
+++ b/MailContainerTest/Data/MailContainerDataStore.cs
@@ -2,7 +2,7 @@
 
 namespace MailContainerTest.Data
 {
-    public class MailContainerDataStore
+    public class MailContainerDataStore : IMailContainerDataStore
     {
         public MailContainer GetMailContainer(string mailContainerNumber)
         {   

--- a/MailContainerTest/Services/Interfaces/IMailTransferService.cs
+++ b/MailContainerTest/Services/Interfaces/IMailTransferService.cs
@@ -1,0 +1,9 @@
+﻿using MailContainerTest.Types;
+
+namespace MailContainerTest.Services.Interfaces
+{
+    public interface IMailTransferService
+    {
+        MakeMailTransferResult MakeMailTransfer(MakeMailTransferRequest request);
+    }
+}

--- a/MailContainerTest/Services/Interfaces/IMailValidator.cs
+++ b/MailContainerTest/Services/Interfaces/IMailValidator.cs
@@ -1,0 +1,9 @@
+﻿using MailContainerTest.Types;
+
+namespace MailContainerTest.Services.Interfaces
+{
+    public interface IMailValidator
+    {
+        bool IsMailValid(MailContainer mailContainer, MakeMailTransferRequest request);
+    }
+}

--- a/MailContainerTest/Services/MailTransferService.cs
+++ b/MailContainerTest/Services/MailTransferService.cs
@@ -1,90 +1,32 @@
 ﻿using MailContainerTest.Data;
+using MailContainerTest.Services.Interfaces;
 using MailContainerTest.Types;
-using System.Configuration;
 
 namespace MailContainerTest.Services
 {
     public class MailTransferService : IMailTransferService
     {
+        private readonly IMailContainerDataStore mailContainerDataStore;
+        private readonly IMailValidator mailValidator;
+        public MailTransferService(IMailContainerDataStore mailContainerDataStore, IMailValidator mailValidator)
+        {
+            this.mailContainerDataStore = mailContainerDataStore;
+            this.mailValidator = mailValidator;
+        }
+
         public MakeMailTransferResult MakeMailTransfer(MakeMailTransferRequest request)
         {
-            var dataStoreType = ConfigurationManager.AppSettings["DataStoreType"];
-
-            MailContainer mailContainer = null;
-
-            if (dataStoreType == "Backup")
+            var mailContainer = mailContainerDataStore.GetMailContainer(request.SourceMailContainerNumber);
+            var result = new MakeMailTransferResult()
             {
-                var mailContainerDataStore = new BackupMailContainerDataStore();
-                mailContainer = mailContainerDataStore.GetMailContainer(request.SourceMailContainerNumber);
+                Success = false
+            };
 
-            } else
-            {
-                var mailContainerDataStore = new MailContainerDataStore();
-                mailContainer = mailContainerDataStore.GetMailContainer(request.SourceMailContainerNumber);
-            }
-
-            var result = new MakeMailTransferResult();
-
-            switch (request.MailType)
-            {
-                case MailType.StandardLetter:
-                    if (mailContainer == null)
-                    {
-                        result.Success = false;
-                    }
-                    else if (!mailContainer.AllowedMailType.HasFlag(AllowedMailType.StandardLetter))
-                    {
-                        result.Success = false;
-                    }
-                    break;
-
-                case MailType.LargeLetter:
-                    if (mailContainer == null)
-                    {
-                        result.Success = false;
-                    }
-                    else if (!mailContainer.AllowedMailType.HasFlag(AllowedMailType.LargeLetter))
-                    {
-                        result.Success = false;
-                    }
-                    else if (mailContainer.Capacity < request.NumberOfMailItems)
-                    {
-                        result.Success = false;
-                    }
-                    break;
-
-                case MailType.SmallParcel:
-                    if (mailContainer == null)
-                    {
-                        result.Success = false;
-                    }
-                    else if (!mailContainer.AllowedMailType.HasFlag(AllowedMailType.SmallParcel))
-                    {
-                        result.Success = false;
-
-                    }
-                    else if (mailContainer.Status != MailContainerStatus.Operational)
-                    {
-                        result.Success = false;
-                    }
-                    break;
-            }
-
-            if (result.Success)
+            if (mailValidator.IsMailValid(mailContainer, request))
             {
                 mailContainer.Capacity -= request.NumberOfMailItems;
-
-                if (dataStoreType == "Backup")
-                {
-                    var mailContainerDataStore = new BackupMailContainerDataStore();
-                    mailContainerDataStore.UpdateMailContainer(mailContainer);
-
-                }
-                else
-                {
-                    var mailContainerDataStore = new MailContainerDataStore();
-                    mailContainerDataStore.UpdateMailContainer(mailContainer);
-                }
+                mailContainerDataStore.UpdateMailContainer(mailContainer);
+                result.Success = true;
             }
 
             return result;

--- a/MailContainerTest/Services/MailValidator.cs
+++ b/MailContainerTest/Services/MailValidator.cs
@@ -1,0 +1,48 @@
+﻿using MailContainerTest.Services.Interfaces;
+using MailContainerTest.Types;
+
+namespace MailContainerTest.Services
+{
+    public class MailValidator : IMailValidator
+    {
+        public bool IsMailValid(MailContainer mailContainer, MakeMailTransferRequest request)
+        {
+            // Check if the mail container was instantiated
+            if (mailContainer == null) return false;
+
+            switch (request.MailType)
+            {
+                case MailType.StandardLetter:
+                    return IsStandardLetterValid(mailContainer);
+
+                case MailType.LargeLetter:
+                    return IsLargeLetterValid(mailContainer, request.NumberOfMailItems);
+
+                case MailType.SmallParcel:
+                    return IsSmallParcelValid(mailContainer);
+
+                default:
+                    break;
+            }
+
+            return false;
+        }
+
+        private static bool IsStandardLetterValid(MailContainer mailContainer)
+        {
+            return mailContainer.AllowedMailType.HasFlag(AllowedMailType.StandardLetter);
+        }
+
+        private static bool IsLargeLetterValid(MailContainer mailContainer, int numberOfMailItems)
+        {
+            return mailContainer.AllowedMailType.HasFlag(AllowedMailType.LargeLetter) &&
+                numberOfMailItems <= mailContainer.Capacity;
+        }
+
+        private static bool IsSmallParcelValid(MailContainer mailContainer)
+        {
+            return mailContainer.AllowedMailType.HasFlag(AllowedMailType.SmallParcel) &&
+                mailContainer.Status == MailContainerStatus.Operational;
+        }
+    }
+}


### PR DESCRIPTION
Refactor MailTransferService and add unit tests

Some of the unit tests have repetitions that could be handled by a helper class and using AutoFixture.

The validator handles whether the mail container is null which could be separated further.

Since it is a refactor I have not changed the original functionality of checking the MailContainerStatus so it is only checked for small parcels.

The service uses an interfacce for mailContainerDataStore. The logic to determine which data store to use was taken out of the service and would be more suitable for a provider or whichever class instantiates this service.  This way the service can run with different data stores that implement the interface.