### PR TITLE
Complete refactoring of the MailContainerTest

### DIFF
--- a/MailContainerTest.Tests/MailContainerTest.Tests.csproj
+++ b/MailContainerTest.Tests/MailContainerTest.Tests.csproj
@@ -1,9 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
 
 </Project>

--- a/MailContainerTest.Tests/MailContainerTest.Tests.csproj
+++ b/MailContainerTest.Tests/MailContainerTest.Tests.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\MailContainerTest\MailContainerTest.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/MailContainerTest.Tests/MailTransferService_Tests.cs
+++ b/MailContainerTest.Tests/MailTransferService_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using MailContainerTest.Services;
 using Moq;
+using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,11 +14,24 @@ namespace MailContainerTest.Tests
         private Mock<IMailContainerDataStoreFactory> _mailContainerDataStoreFactory = default!;
         private Mock<IMailTypeChecker> _mailTypeChecker = default!;
         private Mock<IMailContainerDataStore> _mailContainerDataStore = default!;
-        //private Mock<IConfigurationManager> _configurationManager = default!;
+        private Mock<IConfigurationManager> _configurationManager = default!;
         private Mock<ICheckMailContainerStatus> _checkMailContainer = default!;
         private MailTransferService? _subjectMailTransferService;
         private MailContainerDataStoreFactory? _subjectMailContainerDataStoreFactory;
         private CheckMailContainerStatus _subjectCheckMailContainerStatus = default!;
         private MailTypeChecker _subjectMailTypeChecker = default!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mailContainerDataStoreFactory = new Mock<IMailContainerDataStoreFactory>();
+            _mailTypeChecker = new Mock<IMailTypeChecker>();
+            _configurationManager = new Mock<IConfigurationManager>();
+            _mailContainerDataStore = new Mock<IMailContainerDataStore>();
+            _checkMailContainer = new Mock<ICheckMailContainerStatus>();
+
+            _subjectCheckMailContainerStatus = new CheckMailContainerStatus();
+            _subjectMailTypeChecker = new MailTypeChecker();
+        }
     }
 }

--- a/MailContainerTest.Tests/MailTransferService_Tests.cs
+++ b/MailContainerTest.Tests/MailTransferService_Tests.cs
@@ -66,7 +66,6 @@ namespace MailContainerTest.Tests
 
             _mailContainerDataStore.Setup(x => x.GetMailContainer(It.IsAny<string>())).Returns(new MailContainer());
 
-
             _checkMailContainer.Setup(c => c.CheckContainerStatus(It.IsAny<MailContainer>())).Returns(new MakeMailTransferResult { Success = resultStatus });
 
             _mailTypeChecker.Setup(x => x.CheckMail(MailType.StandardLetter, It.IsAny<MailContainer>())).Returns(new MakeMailTransferResult { Success = resultStatus });
@@ -74,10 +73,128 @@ namespace MailContainerTest.Tests
             _subjectMailTransferService = new MailTransferService(_mailContainerDataStoreFactory.Object,  _checkMailContainer.Object, _mailTypeChecker.Object, _configurationManager.Object);
 
             //act
-            var result = _subjectMailTransferService?.MakeMailTransfer(new Types.MakeMailTransferRequest());
+            var result = _subjectMailTransferService.MakeMailTransfer(new Types.MakeMailTransferRequest());
 
             //assert
             return result?.Success;
         }
+
+
+        [TestCase(MailContainerStatus.OutOfService, ExpectedResult = false)]
+        [TestCase(MailContainerStatus.NoTransfersIn, ExpectedResult = false)]
+        [TestCase(MailContainerStatus.Operational, ExpectedResult = true)]
+        public bool CheckContainerStatus_IfStatusIsNotOperational_ReturnFalse(MailContainerStatus mailContainerStatus)
+        {
+            //arrange
+
+
+            //act
+            var response = _subjectCheckMailContainerStatus.CheckContainerStatus(new MailContainer() { Status = mailContainerStatus });
+
+            //assert
+            return response.Success;
+        }
+
+        [Test]
+        public void CheckMailType_IfMailContainerIsNull_ReturnFalse()
+        {
+            //arrange
+
+            //act
+            var response = _subjectMailTypeChecker.CheckMail(MailType.LargeLetter, null);
+
+            //assert
+            Assert.That(response.Success, Is.False);
+        }
+
+        [TestCase(MailType.LargeLetter, AllowedMailType.LargeLetter, ExpectedResult = true)]
+        [TestCase(MailType.LargeLetter, AllowedMailType.SmallParcel, ExpectedResult = false)]
+        [TestCase(MailType.SmallParcel, AllowedMailType.SmallParcel, ExpectedResult = true)]
+        [TestCase(MailType.StandardLetter, AllowedMailType.LargeLetter, ExpectedResult = false)]
+        [TestCase(MailType.StandardLetter, AllowedMailType.LargeLetter, ExpectedResult = false)]
+        [TestCase(MailType.StandardLetter, AllowedMailType.StandardLetter, ExpectedResult = true)]
+        public bool CheckMailType_IfContainerContainsSameTypeOfMail_ReturnValue(MailType mailType, AllowedMailType allowedMailType)
+        {
+            //arrange
+
+            //act
+            var response = _subjectMailTypeChecker.CheckMail(mailType, new MailContainer { AllowedMailType = allowedMailType });
+
+            //assert
+            return response.Success;
+        }
+
+        [Test]
+        public void MakeMailTransfer_WhenSuccessful_ChangeCapacityCountForSourceAndDestinationMailContainer()
+        {
+            //arrange
+
+            var sourceCapacity = int.MaxValue;
+            var destinationCapacity = 0;
+
+
+            _configurationManager.Setup(x => x.AppSettings(It.IsAny<string>())).Returns("dataStoreType");
+
+            _mailContainerDataStoreFactory.Setup(x => x.CreateMailContainerDataStore(It.IsAny<string>())).Returns(_mailContainerDataStore.Object);
+
+            _mailContainerDataStore.Setup(x => x.GetMailContainer("source")).Returns(new MailContainer { Capacity = sourceCapacity });
+
+            _mailContainerDataStore.Setup(x => x.GetMailContainer("destination")).Returns(new MailContainer { Capacity = destinationCapacity });
+
+            _checkMailContainer.Setup(c => c.CheckContainerStatus(It.IsAny<MailContainer>())).Returns(new MakeMailTransferResult { Success = true });
+
+            _mailTypeChecker.Setup(x => x.CheckMail(MailType.StandardLetter, It.IsAny<MailContainer>())).Returns(new MakeMailTransferResult { Success = true });
+
+            var request = new Types.MakeMailTransferRequest { NumberOfMailItems = 5, SourceMailContainerNumber = "source", DestinationMailContainerNumber = "destination" };
+
+            _subjectMailTransferService = new MailTransferService(_mailContainerDataStoreFactory.Object, _checkMailContainer.Object, _mailTypeChecker.Object, _configurationManager.Object);
+
+            //act
+            var result = _subjectMailTransferService?.MakeMailTransfer(request);
+
+            //assert
+            var sourceMailContainerCapacity = _mailContainerDataStore.Object.GetMailContainer("source").Capacity;
+            var destinationMailContainerCapacity = _mailContainerDataStore.Object.GetMailContainer("destination").Capacity;
+
+            Assert.That(sourceMailContainerCapacity, Is.EqualTo(sourceCapacity - request.NumberOfMailItems));
+            Assert.That(destinationMailContainerCapacity, Is.EqualTo(destinationCapacity + request.NumberOfMailItems));
+        }
+
+        [Test]
+        public void MakeMailTransfer_WhenSuccessful_InvokeUpdateMailContainer()
+        {
+            //arrange
+
+            var sourceCapacity = 1000;
+            var destinationCapacity = 0;
+
+
+            _configurationManager.Setup(x => x.AppSettings(It.IsAny<string>())).Returns("dataStoreType");
+
+            _mailContainerDataStoreFactory.Setup(x => x.CreateMailContainerDataStore(It.IsAny<string>())).Returns(_mailContainerDataStore.Object);
+
+            _mailContainerDataStore.Setup(x => x.GetMailContainer("source")).Returns(new MailContainer { Capacity = sourceCapacity });
+
+            _mailContainerDataStore.Setup(x => x.GetMailContainer("destination")).Returns(new MailContainer { Capacity = destinationCapacity });
+
+            _checkMailContainer.Setup(c => c.CheckContainerStatus(It.IsAny<MailContainer>())).Returns(new MakeMailTransferResult { Success = true });
+
+            _mailTypeChecker.Setup(x => x.CheckMail(MailType.StandardLetter, It.IsAny<MailContainer>())).Returns(new MakeMailTransferResult { Success = true });
+
+            var request = new Types.MakeMailTransferRequest { NumberOfMailItems = 5, SourceMailContainerNumber = "source", DestinationMailContainerNumber = "destination" };
+
+            _subjectMailTransferService = new MailTransferService(_mailContainerDataStoreFactory.Object, _checkMailContainer.Object, _mailTypeChecker.Object, _configurationManager.Object);
+
+            //act
+            var result = _subjectMailTransferService?.MakeMailTransfer(request);
+
+            //assert
+            var sourceMailContainerCapacity = _mailContainerDataStore.Object.GetMailContainer("source");
+            var destinationMailContainerCapacity = _mailContainerDataStore.Object.GetMailContainer("destination");
+
+            _mailContainerDataStore.Verify(x => x.UpdateMailContainer(sourceMailContainerCapacity), times: Times.Once);
+            _mailContainerDataStore.Verify(x => x.UpdateMailContainer(destinationMailContainerCapacity), Times.Once);
+        }
+
     }
 }

--- a/MailContainerTest.Tests/MailTransferService_Tests.cs
+++ b/MailContainerTest.Tests/MailTransferService_Tests.cs
@@ -1,4 +1,6 @@
-﻿using MailContainerTest.Services;
+﻿using MailContainerTest.Data;
+using MailContainerTest.Services;
+using MailContainerTest.Types;
 using Moq;
 using NUnit.Framework;
 using System;
@@ -32,6 +34,50 @@ namespace MailContainerTest.Tests
 
             _subjectCheckMailContainerStatus = new CheckMailContainerStatus();
             _subjectMailTypeChecker = new MailTypeChecker();
+        }
+
+        [Test]
+        public void MailContainerDataStoreFactory_WhenDataStoreTypeIsbackup_ReturnBackUpMailDataStore()
+        {
+            _subjectMailContainerDataStoreFactory = new MailContainerDataStoreFactory();
+            var factory = _subjectMailContainerDataStoreFactory.CreateMailContainerDataStore("backup");
+            Assert.That(factory, Is.InstanceOf<BackupMailContainerDataStore>());
+        }
+
+        [Test]
+        public void MailContainerDataStoreFactory_WhenDataStoreTypeIsNotBackup_ReturnMailContainerDataStore()
+        {
+            _subjectMailContainerDataStoreFactory = new MailContainerDataStoreFactory();
+
+            var factory = _subjectMailContainerDataStoreFactory.CreateMailContainerDataStore("main");
+
+            Assert.That(factory, Is.InstanceOf<MailContainerDataStore>());
+        }
+
+        [TestCase("backup", true, ExpectedResult = true)]
+        [TestCase("whatever", false, ExpectedResult = false)]
+        public bool? MakeMailTransfer_WithBackupDataStoreType_EnsureSuccess(string dataStoreType, bool resultStatus)
+        {
+            //arrange
+
+            _configurationManager.Setup(x => x.AppSettings(It.IsAny<string>())).Returns(dataStoreType);
+
+            _mailContainerDataStoreFactory.Setup(x => x.CreateMailContainerDataStore(It.IsAny<string>())).Returns(new BackupMailContainerDataStore());
+
+            _mailContainerDataStore.Setup(x => x.GetMailContainer(It.IsAny<string>())).Returns(new MailContainer());
+
+
+            _checkMailContainer.Setup(c => c.CheckContainerStatus(It.IsAny<MailContainer>())).Returns(new MakeMailTransferResult { Success = resultStatus });
+
+            _mailTypeChecker.Setup(x => x.CheckMail(MailType.StandardLetter, It.IsAny<MailContainer>())).Returns(new MakeMailTransferResult { Success = resultStatus });
+
+            _subjectMailTransferService = new MailTransferService(_mailContainerDataStoreFactory.Object,  _checkMailContainer.Object, _mailTypeChecker.Object, _configurationManager.Object);
+
+            //act
+            var result = _subjectMailTransferService?.MakeMailTransfer(new Types.MakeMailTransferRequest());
+
+            //assert
+            return result?.Success;
         }
     }
 }

--- a/MailContainerTest.Tests/MailTransferService_Tests.cs
+++ b/MailContainerTest.Tests/MailTransferService_Tests.cs
@@ -3,14 +3,10 @@ using MailContainerTest.Services;
 using MailContainerTest.Types;
 using Moq;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MailContainerTest.Tests
 {
+    [TestFixture]
     public class MailTransferService_Tests
     {
         private Mock<IMailContainerDataStoreFactory> _mailContainerDataStoreFactory = default!;

--- a/MailContainerTest.Tests/MailTransferService_Tests.cs
+++ b/MailContainerTest.Tests/MailTransferService_Tests.cs
@@ -1,0 +1,23 @@
+﻿using MailContainerTest.Services;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Tests
+{
+    public class MailTransferService_Tests
+    {
+        private Mock<IMailContainerDataStoreFactory> _mailContainerDataStoreFactory = default!;
+        private Mock<IMailTypeChecker> _mailTypeChecker = default!;
+        private Mock<IMailContainerDataStore> _mailContainerDataStore = default!;
+        //private Mock<IConfigurationManager> _configurationManager = default!;
+        private Mock<ICheckMailContainerStatus> _checkMailContainer = default!;
+        private MailTransferService? _subjectMailTransferService;
+        private MailContainerDataStoreFactory? _subjectMailContainerDataStoreFactory;
+        private CheckMailContainerStatus _subjectCheckMailContainerStatus = default!;
+        private MailTypeChecker _subjectMailTypeChecker = default!;
+    }
+}

--- a/MailContainerTest/Data/BackupMailContainerDataStore.cs
+++ b/MailContainerTest/Data/BackupMailContainerDataStore.cs
@@ -1,8 +1,9 @@
-﻿using MailContainerTest.Types;
+﻿using MailContainerTest.Services;
+using MailContainerTest.Types;
 
 namespace MailContainerTest.Data
 {
-    public class BackupMailContainerDataStore
+    public class BackupMailContainerDataStore: IMailContainerDataStore
     {
         public MailContainer GetMailContainer(string mailContainerNumber)
         {

--- a/MailContainerTest/Data/MailContainerDataStore.cs
+++ b/MailContainerTest/Data/MailContainerDataStore.cs
@@ -1,8 +1,9 @@
-﻿using MailContainerTest.Types;
+﻿using MailContainerTest.Services;
+using MailContainerTest.Types;
 
 namespace MailContainerTest.Data
 {
-    public class MailContainerDataStore
+    public class MailContainerDataStore : IMailContainerDataStore
     {
         public MailContainer GetMailContainer(string mailContainerNumber)
         {   

--- a/MailContainerTest/Services/CheckMailContainerStatus.cs
+++ b/MailContainerTest/Services/CheckMailContainerStatus.cs
@@ -1,0 +1,26 @@
+﻿using MailContainerTest.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Services
+{
+    public class CheckMailContainerStatus : ICheckMailContainerStatus
+    {
+        public MakeMailTransferResult CheckContainerStatus(MailContainer mailContainer)
+        {
+            MakeMailTransferResult result = new();
+            switch (mailContainer.Status)
+            {
+                case MailContainerStatus.Operational:
+                    result.Success = true;
+                    return result;
+                default:
+                    result.Success = false;
+                    return result;
+            }
+        }
+    }
+}

--- a/MailContainerTest/Services/CustomConfigurationManager.cs
+++ b/MailContainerTest/Services/CustomConfigurationManager.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Services
+{
+    public class CustomConfigurationManager : IConfigurationManager
+    {
+        public string? AppSettings(string? key)
+        {
+            return ConfigurationManager.AppSettings[key];
+        }
+    }
+}

--- a/MailContainerTest/Services/ICheckMailContainerStatus.cs
+++ b/MailContainerTest/Services/ICheckMailContainerStatus.cs
@@ -1,0 +1,14 @@
+﻿using MailContainerTest.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Services
+{
+    public interface ICheckMailContainerStatus
+    {
+        MakeMailTransferResult CheckContainerStatus(MailContainer mailContainer);
+    }
+}

--- a/MailContainerTest/Services/IConfigurationManager.cs
+++ b/MailContainerTest/Services/IConfigurationManager.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Services
+{
+    public interface IConfigurationManager
+    {
+        public string? AppSettings(string? key);
+    }
+}

--- a/MailContainerTest/Services/IMailContainerDataStore.cs
+++ b/MailContainerTest/Services/IMailContainerDataStore.cs
@@ -1,0 +1,15 @@
+﻿using MailContainerTest.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Services
+{
+    public interface IMailContainerDataStore
+    {
+        public MailContainer GetMailContainer(string mailContainerNumber);
+        public void UpdateMailContainer(MailContainer mailContainer);
+    }
+}

--- a/MailContainerTest/Services/IMailContainerDataStoreFactory.cs
+++ b/MailContainerTest/Services/IMailContainerDataStoreFactory.cs
@@ -1,0 +1,14 @@
+﻿using MailContainerTest.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Services
+{
+    public interface IMailContainerDataStoreFactory
+    {
+        IMailContainerDataStore CreateMailContainerDataStore(string? dataStoreType);
+    }
+}

--- a/MailContainerTest/Services/IMailTypeChecker.cs
+++ b/MailContainerTest/Services/IMailTypeChecker.cs
@@ -1,0 +1,14 @@
+﻿using MailContainerTest.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Services
+{
+    public interface IMailTypeChecker
+    {
+        public MakeMailTransferResult CheckMail(MailType mailType, MailContainer mailContainer);
+    }
+}

--- a/MailContainerTest/Services/MailContainerDataStoreFactory.cs
+++ b/MailContainerTest/Services/MailContainerDataStoreFactory.cs
@@ -1,0 +1,24 @@
+﻿using MailContainerTest.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Services
+{
+    public class MailContainerDataStoreFactory : IMailContainerDataStoreFactory
+    {
+        public IMailContainerDataStore CreateMailContainerDataStore(string? dataStoreType)
+        {
+            if (dataStoreType?.Equals("Backup", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return new BackupMailContainerDataStore();
+            }
+            else
+            {
+                return new MailContainerDataStore();
+            }
+        }
+    }
+}

--- a/MailContainerTest/Services/MailTransferService.cs
+++ b/MailContainerTest/Services/MailTransferService.cs
@@ -6,6 +6,10 @@ namespace MailContainerTest.Services
 {
     public class MailTransferService : IMailTransferService
     {
+        public MailTransferService()
+        {
+
+        }
         public MakeMailTransferResult MakeMailTransfer(MakeMailTransferRequest request)
         {
             var dataStoreType = ConfigurationManager.AppSettings["DataStoreType"];

--- a/MailContainerTest/Services/MailTransferService.cs
+++ b/MailContainerTest/Services/MailTransferService.cs
@@ -9,23 +9,23 @@ namespace MailContainerTest.Services
         private readonly IMailContainerDataStoreFactory _mailContainerDataStoreFactory;
         private readonly ICheckMailContainerStatus _checkMailContainerStatus;
         private readonly IMailTypeChecker _mailTypeChecker;
+        private readonly IConfigurationManager _configurationManager;
 
         public MailTransferService(IMailContainerDataStoreFactory mailContainerDataStoreFactory,
                                    ICheckMailContainerStatus checkMailContainerStatus,
-                                   IMailTypeChecker mailTypeChecker)
+                                   IMailTypeChecker mailTypeChecker,
+                                   IConfigurationManager configurationManager)
         {
             _mailContainerDataStoreFactory = mailContainerDataStoreFactory;
             _checkMailContainerStatus = checkMailContainerStatus;
             _mailTypeChecker = mailTypeChecker;
+            _configurationManager = configurationManager;
         }
         public MakeMailTransferResult MakeMailTransfer(MakeMailTransferRequest request)
         {
-
-            var dataStoreType = ConfigurationManager.AppSettings["DataStoreType"];
-            var mailContainerStoreFactory = _mailContainerDataStoreFactory.CreateMailContainerDataStore(dataStoreType);
+            var mailContainerStoreFactory = _mailContainerDataStoreFactory.CreateMailContainerDataStore(_configurationManager.AppSettings("DataStoreType"));
 
             var sourceMailContainer = mailContainerStoreFactory.GetMailContainer(request.SourceMailContainerNumber);
-
 
             MakeMailTransferResult sourceResultCheck = _checkMailContainerStatus.CheckContainerStatus(sourceMailContainer);
 
@@ -35,7 +35,6 @@ namespace MailContainerTest.Services
             }
 
             sourceResultCheck = _mailTypeChecker.CheckMail(request.MailType, sourceMailContainer);
-
 
             if (sourceResultCheck.Success)
             {

--- a/MailContainerTest/Services/MailTransferService.cs
+++ b/MailContainerTest/Services/MailTransferService.cs
@@ -7,10 +7,12 @@ namespace MailContainerTest.Services
     public class MailTransferService : IMailTransferService
     {
         private readonly IMailContainerDataStoreFactory _mailContainerDataStoreFactory;
+        private readonly ICheckMailContainerStatus _checkMailContainerStatus;
 
-        public MailTransferService(IMailContainerDataStoreFactory mailContainerDataStoreFactory)
+        public MailTransferService(IMailContainerDataStoreFactory mailContainerDataStoreFactory, ICheckMailContainerStatus checkMailContainerStatus)
         {
             _mailContainerDataStoreFactory = mailContainerDataStoreFactory;
+            _checkMailContainerStatus = checkMailContainerStatus;
         }
         public MakeMailTransferResult MakeMailTransfer(MakeMailTransferRequest request)
         {
@@ -20,18 +22,13 @@ namespace MailContainerTest.Services
 
             var sourceMailContainer = mailContainerStoreFactory.GetMailContainer(request.SourceMailContainerNumber);
 
-            if (dataStoreType == "Backup")
-            {
-                var mailContainerDataStore = new BackupMailContainerDataStore();
-                mailContainer = mailContainerDataStore.GetMailContainer(request.SourceMailContainerNumber);
 
-            } else
+            MakeMailTransferResult result = _checkMailContainerStatus.CheckContainerStatus(sourceMailContainer);
+
+            if (!result.Success)
             {
-                var mailContainerDataStore = new MailContainerDataStore();
-                sourceMailContainer = mailContainerDataStore.GetMailContainer(request.SourceMailContainerNumber);
+                return result;
             }
-
-            var result = new MakeMailTransferResult();
 
             switch (request.MailType)
             {

--- a/MailContainerTest/Services/MailTransferService.cs
+++ b/MailContainerTest/Services/MailTransferService.cs
@@ -8,11 +8,15 @@ namespace MailContainerTest.Services
     {
         private readonly IMailContainerDataStoreFactory _mailContainerDataStoreFactory;
         private readonly ICheckMailContainerStatus _checkMailContainerStatus;
+        private readonly IMailTypeChecker _mailTypeChecker;
 
-        public MailTransferService(IMailContainerDataStoreFactory mailContainerDataStoreFactory, ICheckMailContainerStatus checkMailContainerStatus)
+        public MailTransferService(IMailContainerDataStoreFactory mailContainerDataStoreFactory,
+                                   ICheckMailContainerStatus checkMailContainerStatus,
+                                   IMailTypeChecker mailTypeChecker)
         {
             _mailContainerDataStoreFactory = mailContainerDataStoreFactory;
             _checkMailContainerStatus = checkMailContainerStatus;
+            _mailTypeChecker = mailTypeChecker;
         }
         public MakeMailTransferResult MakeMailTransfer(MakeMailTransferRequest request)
         {
@@ -30,50 +34,8 @@ namespace MailContainerTest.Services
                 return result;
             }
 
-            switch (request.MailType)
-            {
-                case MailType.StandardLetter:
-                    if (sourceMailContainer == null)
-                    {
-                        result.Success = false;
-                    }
-                    else if (!sourceMailContainer.AllowedMailType.HasFlag(AllowedMailType.StandardLetter))
-                    {
-                        result.Success = false;
-                    }
-                    break;
+            result = _mailTypeChecker.CheckMail(request.MailType, sourceMailContainer);
 
-                case MailType.LargeLetter:
-                    if (sourceMailContainer == null)
-                    {
-                        result.Success = false;
-                    }
-                    else if (!sourceMailContainer.AllowedMailType.HasFlag(AllowedMailType.LargeLetter))
-                    {
-                        result.Success = false;
-                    }
-                    else if (sourceMailContainer.Capacity < request.NumberOfMailItems)
-                    {
-                        result.Success = false;
-                    }
-                    break;
-
-                case MailType.SmallParcel:
-                    if (sourceMailContainer == null)
-                    {
-                        result.Success = false;
-                    }
-                    else if (!sourceMailContainer.AllowedMailType.HasFlag(AllowedMailType.SmallParcel))
-                    {
-                        result.Success = false;
-
-                    }
-                    else if (sourceMailContainer.Status != MailContainerStatus.Operational)
-                    {
-                        result.Success = false;
-                    }
-                    break;
-            }
 
             if (result.Success)
             {

--- a/MailContainerTest/Services/MailTypeChecker.cs
+++ b/MailContainerTest/Services/MailTypeChecker.cs
@@ -1,0 +1,70 @@
+﻿using MailContainerTest.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MailContainerTest.Services
+{
+    public class MailTypeChecker : IMailTypeChecker
+    {
+        public MakeMailTransferResult CheckMail(MailType mailType, MailContainer mailContainer)
+        {
+            var result = new MakeMailTransferResult();
+
+            if (mailContainer == null)
+            {
+                result.Success = false;
+                return result;
+            }
+
+            switch (mailType)
+            {
+                case MailType.StandardLetter:
+
+                    if (!mailContainer.AllowedMailType.Equals(AllowedMailType.StandardLetter))
+                    {
+                        result.Success = false;
+                    }
+                    else
+                    {
+                        result.Success = true;
+                    }
+                    break;
+
+                case MailType.LargeLetter:
+
+                    if (!mailContainer.AllowedMailType.Equals(AllowedMailType.LargeLetter))
+                    {
+                        result.Success = false;
+                    }
+                    else
+                    {
+                        result.Success = true;
+                    }
+
+                    break;
+
+                case MailType.SmallParcel:
+
+                    if (!mailContainer.AllowedMailType.Equals(AllowedMailType.SmallParcel))
+                    {
+                        result.Success = false;
+
+                    }
+                    else
+                    {
+                        result.Success = true;
+                    }
+                    break;
+
+                default:
+                    result.Success = false;
+                    break;
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
This is my complete refactor of the MailContainerTest.

I tried to keep it under 2 hours however there are still quite a few activities i would love to add if i had more than 2 hours.

some of which are

1. add singleton pattern to my  data store factory class to ensure only one instance is created
2. create other classes for my unit test so as to seperate concerns and put each unit test in each of its class
3. add a unit test to test successful makemailtransfer with maildatasource (not backup)
4. make the unit test run faster. at the moment the run time of one is high. i did not have the time to debug why it was so.
5. sort and remove using statements
6. add other several unit tests